### PR TITLE
fix crash on ICS

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/service/ServerSyncService.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/service/ServerSyncService.java
@@ -2,7 +2,10 @@ package de.stephanlindauer.criticalmaps.service;
 
 import android.app.Service;
 import android.content.Intent;
+import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 
 import java.util.Timer;
 import java.util.TimerTask;
@@ -31,7 +34,19 @@ public class ServerSyncService extends Service {
         TimerTask timerTaskPullServer = new TimerTask() {
             @Override
             public void run() {
-                new PullServerHandler().execute();
+                // Since JELLYBEAN AsyncTask makes sure it's started from
+                // the UI thread. Before that we have do to that ourselves.
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+                    Handler handler = new Handler(Looper.getMainLooper());
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            new PullServerHandler().execute();
+                        }
+                    });
+                } else {
+                    new PullServerHandler().execute();
+                }
             }
         };
         timerPullServer.scheduleAtFixedRate(timerTaskPullServer, 0, PULL_OTHER_LOCATIONS_TIME);


### PR DESCRIPTION
AsyncTasks must be started from the UI thread and as of JELLYBEAN this is automatically taken care of.
Since we're running it from a TimerTask - which is a separate thread - we have to take care of this ourselves
for devices running ICS and lower.
fixes #42