### PR TITLE
Migrate to okhttp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
     - build-tools-23.0.1
 
     # The SDK version used to compile your project
-    - android-22
+    - android-23
 
     # Additional components
 #    - extra-google-google_play_services

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 23
     buildToolsVersion "23.0.1"
 
     defaultConfig {
@@ -20,7 +20,8 @@ android {
     }
 
     lintOptions {
-        disable 'MissingTranslation'
+        warning 'MissingTranslation'
+        warning 'InvalidPackage' // https://github.com/square/okio/issues/58
     }
 
     compileOptions {
@@ -35,7 +36,8 @@ dependencies {
     compile 'org.osmdroid:osmdroid-android:4.3'
     compile 'org.slf4j:slf4j-simple:1.6.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.android.support:support-v4:22.2.1'
-    compile 'com.android.support:appcompat-v7:22.2.1'
-    compile 'com.android.support:design:22.2.1'
+    compile 'com.android.support:support-v4:23.0.1'
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:design:23.0.1'
+    compile 'com.squareup.okhttp:okhttp:2.5.0'
 }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/provider/EventBusProvider.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/provider/EventBusProvider.java
@@ -4,27 +4,27 @@ import com.squareup.otto.Bus;
 
 public class EventBusProvider {
 
-    private Bus bus = new Bus();
+    private final Bus bus = new Bus();
 
     //singleton
     private static EventBusProvider instance;
 
     public static EventBusProvider getInstance() {
-        if (EventBusProvider.instance == null) {
-            EventBusProvider.instance = new EventBusProvider();
+        if (instance == null) {
+            instance = new EventBusProvider();
         }
-        return EventBusProvider.instance;
+        return instance;
     }
 
     public void post(Object event) {
         bus.post(event);
     }
 
-    public void register(java.lang.Object object) {
+    public void register(Object object) {
         bus.register(object);
     }
 
-    public void unregister(java.lang.Object object) {
+    public void unregister(Object object) {
         bus.unregister(object);
     }
 }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/provider/HttpClientProvider.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/provider/HttpClientProvider.java
@@ -1,0 +1,19 @@
+package de.stephanlindauer.criticalmaps.provider;
+
+import com.squareup.okhttp.OkHttpClient;
+import java.util.concurrent.TimeUnit;
+
+public class HttpClientProvider {
+
+    public static final int TIME_OUT_IN_S = 15;
+
+    private static OkHttpClient instance;
+
+    public static OkHttpClient get() {
+        if (instance == null) {
+            instance = new OkHttpClient();
+            instance.setConnectTimeout(TIME_OUT_IN_S, TimeUnit.SECONDS);
+        }
+        return instance;
+    }
+}


### PR DESCRIPTION
OKHttp is a good replacement do handle the deprecations that come with SDK23 - also shortens the code here - could even have some other benefits - from the website: 

```
HTTP is the way modern applications network. It’s how we exchange data & media. Doing HTTP efficiently makes your stuff load faster and saves bandwidth.

OkHttp is an HTTP client that’s efficient by default:

HTTP/2 and SPDY support allows all requests to the same host to share a socket.
Connection pooling reduces request latency (if SPDY isn’t available).
Transparent GZIP shrinks download sizes.
Response caching avoids the network completely for repeat requests.
OkHttp perseveres when the network is troublesome: it will silently recover from common connection problems. If your service has multiple IP addresses OkHttp will attempt alternate addresses if the first connect fails. This is necessary for IPv4+IPv6 and for services hosted in redundant data centers. OkHttp initiates new connections with modern TLS features (SNI, ALPN), and falls back to TLS 1.0 if the handshake fails.
```
