### PR TITLE
Fix text color in rules image source

### DIFF
--- a/app/src/main/res/layout/fragment_rules.xml
+++ b/app/src/main/res/layout/fragment_rules.xml
@@ -146,14 +146,8 @@
             </LinearLayout>
 
             <TextView
-                android:id="@+id/textView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:autoLink="web"
-                android:padding="10dp"
-                android:text="@string/rules_image_source"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                style="@style/rules_image_source_text"
+                android:text="@string/rules_image_source" />
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,6 +30,17 @@
         <item name="android:layout_height">fill_parent</item>
     </style>
 
+    <style name="rules_image_source_text">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:autoLink">web</item>
+        <item name="android:padding">10dp</item>
+        <!-- FIXME direct usage of color -->
+        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textAppearance">?android:attr/textAppearanceSmall</item>
+    </style>
+
     <style name="about_heading">
         <item name="android:textSize">20dp</item>
         <item name="android:textColor">@color/about_heading_text</item>


### PR DESCRIPTION
currently the text around the link is white on white

btw. we should probably think about making the color definitions more general and not view specific to avoid redundandcy.