### PR TITLE
fix NPE on twitter fragment

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/handler/TwitterGetHandler.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/handler/TwitterGetHandler.java
@@ -45,6 +45,10 @@ public class TwitterGetHandler extends AsyncTask<Void, Void, ResultType> {
 
     @Override
     protected void onPostExecute(ResultType resultType) {
+        if (!twitterFragment.isAdded()) {
+            return;
+        }
+
         if (resultType == ResultType.FAILED) {
             twitterFragment.showErrorMessage();
         } else {


### PR DESCRIPTION
when we navigate away from the twitter fragment while
an asynctask is still running it will triger an update to
views which have already been destroyed and thus
causes a NPE.
check if the fragment is added before trying to update it

fixes #92 