### PR TITLE
Tweet layout

### DIFF
--- a/app/src/main/res/layout/view_tweet.xml
+++ b/app/src/main/res/layout/view_tweet.xml
@@ -5,85 +5,70 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/linearLayout"
+    <ProgressBar
+        android:layout_width="@dimen/tweet_user_image_dimension"
+        android:layout_height="@dimen/tweet_user_image_dimension"
+        android:layout_margin="@dimen/tweet_user_image_margin"
+        android:layout_alignParentLeft="true"
+        android:background="@color/tweet_progress_bar_background" />
+
+    <ImageView
+        android:id="@+id/tweet_user_image"
+        android:layout_width="@dimen/tweet_user_image_dimension"
+        android:layout_height="@dimen/tweet_user_image_dimension"
+        android:layout_margin="@dimen/tweet_user_image_margin"
+        android:layout_alignParentLeft="true"
+        tools:src="@drawable/ic_logo" />
+
+    <TextView
+        android:id="@+id/tweet_user_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_marginTop="@dimen/tweet_content_margin"
+        android:layout_toRightOf="@id/tweet_user_image"
+        android:textStyle="bold"
+        tools:text="Critical Maps" />
 
-        <RelativeLayout
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_margin="10dp">
+    <TextView
+        android:id="@+id/tweet_user_handle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/tweet_user_name"
+        android:layout_marginTop="@dimen/tweet_content_padding"
+        android:layout_toRightOf="@id/tweet_user_image"
+        android:textStyle="italic"
+        tools:text="\@CriticalMaps" />
 
-            <ProgressBar
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/tweet_progress_bar_background" />
+    <TextView
+        android:id="@+id/tweet_creation_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentTop="true"
+        android:layout_marginRight="@dimen/tweet_content_margin"
+        android:layout_marginTop="@dimen/tweet_content_margin"
+        tools:text="01.01.2015" />
 
-            <ImageView
-                android:id="@+id/tweet_user_image"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                tools:src="@drawable/ic_logo" />
-
-        </RelativeLayout>
-
-        <RelativeLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="10dp"
-            android:layout_marginTop="10dp"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/tweet_user_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                tools:text="Critical Maps"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/tweet_user_handle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/tweet_user_name"
-                android:layout_marginTop="5dp"
-                tools:text="\@CriticalMaps"
-                android:textStyle="italic" />
-
-            <TextView
-                android:id="@+id/tweet_creation_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentTop="true"
-                tools:text="01.01.2015" />
-
-            <TextView
-                android:id="@+id/tweet_creation_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_below="@id/tweet_creation_date"
-                android:layout_marginTop="5dp"
-                tools:text="19:30" />
-
-        </RelativeLayout>
-
-    </LinearLayout>
+    <TextView
+        android:id="@+id/tweet_creation_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
+        android:layout_below="@id/tweet_creation_date"
+        android:layout_marginRight="@dimen/tweet_content_margin"
+        android:layout_marginTop="@dimen/tweet_content_padding"
+        tools:text="19:30" />
 
     <TextView
         android:id="@+id/tweet_text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentRight="true"
-        android:layout_below="@+id/linearLayout"
-        android:layout_marginBottom="10dp"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:layout_marginTop="0dp"
+        android:layout_below="@+id/tweet_user_image"
+        android:layout_marginBottom="@dimen/tweet_content_margin"
+        android:layout_marginLeft="@dimen/tweet_content_margin"
+        android:layout_marginRight="@dimen/tweet_content_margin"
         tools:text="@string/lorem_ipsum" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/view_tweet.xml
+++ b/app/src/main/res/layout/view_tweet.xml
@@ -10,6 +10,7 @@
         android:layout_height="@dimen/tweet_user_image_dimension"
         android:layout_margin="@dimen/tweet_user_image_margin"
         android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
         android:background="@color/tweet_progress_bar_background" />
 
     <ImageView
@@ -18,6 +19,7 @@
         android:layout_height="@dimen/tweet_user_image_dimension"
         android:layout_margin="@dimen/tweet_user_image_margin"
         android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
         tools:src="@drawable/ic_logo" />
 
     <TextView
@@ -26,6 +28,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/tweet_content_margin"
         android:layout_toRightOf="@id/tweet_user_image"
+        android:layout_toEndOf="@id/tweet_user_image"
         android:textStyle="bold"
         tools:text="Critical Maps" />
 
@@ -36,6 +39,7 @@
         android:layout_below="@id/tweet_user_name"
         android:layout_marginTop="@dimen/tweet_content_padding"
         android:layout_toRightOf="@id/tweet_user_image"
+        android:layout_toEndOf="@id/tweet_user_image"
         android:textStyle="italic"
         tools:text="\@CriticalMaps" />
 
@@ -44,8 +48,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_alignParentTop="true"
         android:layout_marginRight="@dimen/tweet_content_margin"
+        android:layout_marginEnd="@dimen/tweet_content_margin"
         android:layout_marginTop="@dimen/tweet_content_margin"
         tools:text="01.01.2015" />
 
@@ -54,8 +60,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_below="@id/tweet_creation_date"
         android:layout_marginRight="@dimen/tweet_content_margin"
+        android:layout_marginEnd="@dimen/tweet_content_margin"
         android:layout_marginTop="@dimen/tweet_content_padding"
         tools:text="19:30" />
 
@@ -64,7 +72,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
         android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"
         android:layout_below="@+id/tweet_user_image"
         android:layout_marginBottom="@dimen/tweet_content_margin"
         android:layout_marginLeft="@dimen/tweet_content_margin"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Tweet -->
+    <dimen name="tweet_content_margin">10dp</dimen>
+    <dimen name="tweet_content_padding">5dp</dimen>
+    <dimen name="tweet_user_image_dimension">50dp</dimen>
+    <dimen name="tweet_user_image_margin">10dp</dimen>
+
+</resources>


### PR DESCRIPTION
# View hierarchy

I took a look at the view hierarchy of the app. I found the layout for the **tweet layout** too complex. So I refactored this.

@ligi @cbalster @stephanlindauer
Please run this on your devices (also tablets) to check if tweets still layout fine.

### View hierarchy before

![hierarchy-view-before](https://cloud.githubusercontent.com/assets/144518/10612468/383e1a6a-7751-11e5-8e3f-102a018f9d8b.png)

### View hierarchy after

![hierarchy-view-after](https://cloud.githubusercontent.com/assets/144518/10612472/407a9d48-7751-11e5-9e73-9944a16e8656.png)

# RTL support

I also added the needed attributes to prepare the view for right-to-left mode.

![Preview of the tweet layout in RTL mode](https://cloud.githubusercontent.com/assets/144518/10612480/476290c0-7751-11e5-9f0e-2acccb9e2fc7.png)

