### PR TITLE
Color cleanup

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/TwitterFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/TwitterFragment.java
@@ -67,7 +67,10 @@ public class TwitterFragment extends Fragment {
                 new TwitterGetHandler(TwitterFragment.this).execute();
             }
         });
-        swipeLayout.setColorSchemeResources(R.color.colorAccent, R.color.colorPrimary);
+
+        swipeLayout.setColorSchemeResources(
+                R.color.twitter_indicator_color_first,
+                R.color.twitter_indicator_color_second);
 
         errorButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/TwitterFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/TwitterFragment.java
@@ -67,7 +67,7 @@ public class TwitterFragment extends Fragment {
                 new TwitterGetHandler(TwitterFragment.this).execute();
             }
         });
-        swipeLayout.setColorSchemeResources(android.R.color.holo_blue_bright, android.R.color.darker_gray);
+        swipeLayout.setColorSchemeResources(R.color.colorAccent, R.color.colorPrimary);
 
         errorButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/res/drawable-nodpi/border_bottom.xml
+++ b/app/src/main/res/drawable-nodpi/border_bottom.xml
@@ -2,12 +2,12 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/colorAccent" />
+            <solid android:color="@color/border_bottom_divider" />
         </shape>
     </item>
     <item android:bottom="1dp">
         <shape android:shape="rectangle">
-            <solid android:color="@color/colorPrimaryDark" />
+            <solid android:color="@color/border_bottom_background" />
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable-nodpi/border_bottom.xml
+++ b/app/src/main/res/drawable-nodpi/border_bottom.xml
@@ -2,12 +2,12 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#ff5d5d5d" />
+            <solid android:color="@color/colorAccent" />
         </shape>
     </item>
     <item android:bottom="1dp">
         <shape android:shape="rectangle">
-            <solid android:color="#000000" />
+            <solid android:color="@color/colorPrimaryDark" />
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable-nodpi/border_top.xml
+++ b/app/src/main/res/drawable-nodpi/border_top.xml
@@ -2,12 +2,12 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="@color/colorPrimary" />
+            <solid android:color="@color/border_top_divider" />
         </shape>
     </item>
     <item android:top="1dp">
         <shape android:shape="rectangle">
-            <solid android:color="@color/colorPrimaryDark" />
+            <solid android:color="@color/border_top_background" />
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/drawable-nodpi/border_top.xml
+++ b/app/src/main/res/drawable-nodpi/border_top.xml
@@ -2,12 +2,12 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#ff5d5d5d" />
+            <solid android:color="@color/colorPrimary" />
         </shape>
     </item>
     <item android:top="1dp">
         <shape android:shape="rectangle">
-            <solid android:color="#000000" />
+            <solid android:color="@color/colorPrimaryDark" />
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/layout/fragment_twitter.xml
+++ b/app/src/main/res/layout/fragment_twitter.xml
@@ -14,8 +14,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/border_bottom"
         android:padding="10dp"
-        android:text="@string/twitter_heading"
-        tools:textColor="@android:color/holo_blue_light"/>
+        android:text="@string/twitter_heading" />
 
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/swipe_container"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -28,9 +28,18 @@
     <!-- Twitter -->
     <color name="twitter_background">@color/colorPrimaryDark</color>
     <color name="twitter_error_message_text">@color/material_red_900</color>
+    <color name="twitter_indicator_color_first">@color/colorAccent</color>
+    <color name="twitter_indicator_color_second">@color/colorPrimary</color>
 
     <!-- Tweet -->
     <color name="tweet_progress_bar_background">@color/colorPrimary</color>
+
+    <!-- Header/Footer used in chat and twitter fragment -->
+    <color name="border_bottom_background">@color/colorPrimaryDark</color>
+    <color name="border_bottom_divider">@color/colorAccent</color>
+
+    <color name="border_top_background">@color/colorPrimaryDark</color>
+    <color name="border_top_divider">@color/colorPrimary</color>
 
     <!-- Search for location overlay -->
     <color name="location_search_background">@color/window_background</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,20 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- Material colors used but not present in appcompat -->
+    <color name="material_red_900">#FFB71C1C</color>
+
     <!-- Theme Colors -->
     <color name="colorPrimary">@color/material_grey_800</color>
     <color name="colorPrimaryDark">@color/material_grey_900</color>
     <color name="colorAccent">@color/material_deep_teal_200</color>
+    <color name="window_background">@color/material_grey_850</color> <!-- appcompat default: material_grey_850  -->
 
     <!-- About -->
     <color name="about_background">@android:color/white</color>
-    <color name="about_heading_background">#ff0a0a0a</color>
+    <color name="about_heading_background">@color/colorPrimary</color>
     <color name="about_heading_text">@android:color/white</color>
     <color name="about_content_text">@android:color/black</color>
     <color name="about_button_text">@android:color/black</color>
 
     <!-- Chat -->
-    <color name="chat_background">#222</color>
+    <color name="chat_background">@color/colorPrimaryDark</color>
 
     <!-- Rules -->
     <color name="rules_background">@android:color/white</color>
@@ -22,13 +26,13 @@
     <color name="rules_button_text">@android:color/white</color>
 
     <!-- Twitter -->
-    <color name="twitter_background">#222</color>
-    <color name="twitter_error_message_text">#b20e17</color>
+    <color name="twitter_background">@color/colorPrimaryDark</color>
+    <color name="twitter_error_message_text">@color/material_red_900</color>
 
     <!-- Tweet -->
-    <color name="tweet_progress_bar_background">#222</color>
+    <color name="tweet_progress_bar_background">@color/colorPrimary</color>
 
     <!-- Search for location overlay -->
-    <color name="location_search_background">#444</color>
+    <color name="location_search_background">@color/window_background</color>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-
+        <item name="android:windowBackground">@color/window_background</item>
     </style>
 
     <style name="AlertDialogTheme" parent="Theme.AppCompat.Dialog.Alert">>


### PR DESCRIPTION
I think we have some cleanup to do regarding the different colors used in the app, especially when moving to a more material design. So firstly this reduces the number of colors by trying to replace them by a few common ones. Secondly this moves all color definitions to the colors.xml to have them in a common place.
Obviously this changes the appearance of the app a bit. Something that proved a bit problematic is that our current primary primary dark color is really close to the default Theme.Appcompat window background. Especially I'm not too happy with the background of the chat edittext (even though I think it'll just do for now). Therefore I added it to the colors and style, to prepare a change here.
So this should be seen as a first step to get things organized and moving to a defined palette of colors that covers all use cases and can be used in all our UI elements. I'll probably open a new issue regarding this.

![chat](https://cloud.githubusercontent.com/assets/9266843/10641382/5525db18-7819-11e5-85a9-92b0ea7469a4.png)
![twitter](https://cloud.githubusercontent.com/assets/9266843/10641390/5ca15106-7819-11e5-8c82-87506fdcdf29.png)
![about](https://cloud.githubusercontent.com/assets/9266843/10641405/6609e26c-7819-11e5-860a-4a8fbc091333.png)


