### PR TITLE
close response body after use

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/handler/PullServerHandler.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/handler/PullServerHandler.java
@@ -50,7 +50,9 @@ public class PullServerHandler extends AsyncTask<Void, Void, String> {
         try {
             final Response response = okHttpClient.newCall(postRequest).execute();
             if (response.code() == HttpURLConnection.HTTP_OK) {
-                return response.body().string();
+                String responseBody = response.body().string();
+                response.body().close();
+                return responseBody;
             }
         } catch (IOException e) {
             Log.e(LOG_TAG, Log.getStackTraceString(e));


### PR DESCRIPTION
quote from docs: "To facilitate connection recycling, callers should always close the response body."