### PR TITLE
transparent side drawer

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,5 +33,6 @@
         app:itemIconTint="@android:color/white"
         app:itemTextColor="@android:color/white"
         app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer" />
+        app:menu="@menu/drawer"
+        android:background="@color/transparent_background"/>
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,7 +12,7 @@
 
     <!-- Transparent colors -->
     <color name="white_60pct">#99FFFFFF</color>
-    <color name="transparent_background">#CC424242</color>
+    <color name="transparent_background">#CC424242</color> 
 
     <!-- Map -->
     <color name="map_osm_notice">@color/white_60pct</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
 
     <!-- Transparent colors -->
     <color name="white_60pct">#99FFFFFF</color>
+    <color name="transparent_background">#CC424242</color>
 
     <!-- Map -->
     <color name="map_osm_notice">@color/white_60pct</color>


### PR DESCRIPTION
i kinda want to get the discussion going on this one. i think it looks nice and it improves usability by not completely covering the currently active fragment. what do you think?
maybe we can let the side drawer slide in below the action bar so we can still access the camera and settings button and have the hamburger button as another way of closing the side drawer.