### PR TITLE
Chat location state handling

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
@@ -44,7 +44,6 @@ import de.stephanlindauer.criticalmaps.vo.chat.OutgoingChatMessage;
 public class ChatFragment extends Fragment {
 
     //dependencies
-
     @Inject
     ChatModel chatModel;
 
@@ -64,14 +63,12 @@ public class ChatFragment extends Fragment {
     @Bind(R.id.chat_edit_message)
     EditText editMessageTextField;
 
-    @Bind(R.id.searching_for_location_overlay_chat)
-    RelativeLayout searchingForLocationOverlay;
-
     @Bind(R.id.chat_send_btn)
     FloatingActionButton sendButton;
 
     //misc
     private boolean isScrolling = false;
+    private boolean isTextInputEnabled = true;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -131,7 +128,7 @@ public class ChatFragment extends Fragment {
         });
 
         if (ownLocationModel.ownLocation == null) {
-            searchingForLocationOverlay.setVisibility(View.VISIBLE);
+            setTextInputEnabled(false);
         }
     }
 
@@ -180,7 +177,7 @@ public class ChatFragment extends Fragment {
 
     @Subscribe
     public void handleNewLocation(NewLocationEvent e) {
-        setSearchingForLocationOverlayState();
+        setTextInputEnabled(true);
     }
 
     @Subscribe
@@ -188,9 +185,15 @@ public class ChatFragment extends Fragment {
         chatModelToAdapter();
     }
 
-    public void setSearchingForLocationOverlayState() {
-        if (ownLocationModel.ownLocation != null) {
-            searchingForLocationOverlay.setVisibility(View.GONE);
+    public void setTextInputEnabled(final boolean enabled) {
+        if (!enabled) {
+            editMessageTextField.setEnabled(false);
+            textInputLayout.setHint(getString(R.string.map_searching_for_location));
+            isTextInputEnabled = false;
+        } else if (!isTextInputEnabled) {
+            editMessageTextField.setEnabled(true);
+            textInputLayout.setHint(getString(R.string.chat_text));
+            isTextInputEnabled = true;
         }
     }
 }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
@@ -185,7 +185,6 @@ public class ChatFragment extends Fragment {
 
     @Subscribe
     public void handleNewServerData(NewServerResponseEvent e) {
-        setSearchingForLocationOverlayState();
         chatModelToAdapter();
     }
 

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -64,7 +64,7 @@
                     app:elevation="4dp"
                     app:fabSize="mini"
                     android:visibility="gone"
-                    android:layout_gravity="bottom"
+                    android:layout_gravity="center_vertical"
                     android:layout_margin="8dp"
                     />
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -69,8 +69,4 @@
                     />
         </LinearLayout>
     </LinearLayout>
-    <include
-            android:id="@+id/searching_for_location_overlay_chat"
-            layout="@layout/view_searching_for_location_overlay"
-            android:visibility="gone"/>
 </FrameLayout>


### PR DESCRIPTION
As we agreed the overlay is not the most visually appealing way to indicate we're still waiting for a location fix. Let's get rid of it by disabling the EditText and showing a message in the hint text instead. I think the state change should be made more obvious for example by adding an animation, but one step at a time ;)