### PR TITLE
ImageUploadHandler: fix progress update

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/handler/ImageUploadHandler.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/handler/ImageUploadHandler.java
@@ -60,7 +60,7 @@ public class ImageUploadHandler extends AsyncTask<Void, Integer, ResultType> {
         final ProgressListener progressListener = new ProgressListener() {
             @Override
             public void update(long bytesRead, long contentLength) {
-                onProgressUpdate((int) ((100 * bytesRead) / contentLength));
+                publishProgress((int) ((100 * bytesRead) / contentLength));
             }
         };
 


### PR DESCRIPTION
even though this works we should use publishProgress()
to ensure proper synchronization