### PR TITLE
Deeplink experiment

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,10 +32,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <data android:scheme="criticalmaps" />
             </intent-filter>
-            <receiver
-                android:name="de.stephanlindauer.Receiver" android:exported="true"></receiver>
         </activity>
 
+        <receiver
+            android:name="de.stephanlindauer.criticalmaps.receivers.Receiver"
+            android:exported="true"/>
         <service
             android:name=".service.ServerSyncService"/>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,8 +27,13 @@
             android:theme="@style/AppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <data android:scheme="criticalmaps" />
             </intent-filter>
+            <receiver
+                android:name="de.stephanlindauer.Receiver" android:exported="true"></receiver>
         </activity>
 
         <service

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/receivers/Receiver.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/receivers/Receiver.java
@@ -5,9 +5,17 @@ import android.content.Context;
 import android.content.Intent;
 
 public class Receiver extends BroadcastReceiver {
+    //TODO remove this whole class when deeplinking works properly
     @Override
     public void onReceive(Context context, Intent intent) {
-        String referrer = intent.getStringExtra("referrer");
-        System.out.println("referrer test: " + referrer);
+        if (intent.hasExtra("referrer")) {
+            String referrer = intent.getStringExtra("referrer");
+            System.out.println("referrer test 'referrer': " + referrer);
+        }
+        //this serves as a fallback when chrome overrides "referrer"
+        if (intent.hasExtra("foobar")) {
+            String fallbackReferrer = intent.getStringExtra("foobar");
+            System.out.println("referrer test: 'foobar'" + fallbackReferrer);
+        }
     }
 }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/receivers/Receiver.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/receivers/Receiver.java
@@ -1,0 +1,13 @@
+package de.stephanlindauer.criticalmaps.receivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class Receiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String referrer = intent.getStringExtra("referrer");
+        System.out.println("referrer test: " + referrer);
+    }
+}


### PR DESCRIPTION
i want to deeplink from "app" tab on http://criticalmaps.net into the app. 

testing this locally always redirected me into the play store which, i assume, was because the apk was not signed with the play store certificate.
i want to get this code in to see if this finally works when the app is installed not by adb but by the play store. i will remove the Receiver after the next release again as we don't really need it.