### PR TITLE
Add slack notifications to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,6 @@ before_install:
  - chmod +x gradlew
 
 script: 'travis_retry ./gradlew clean build'
+
+notifications:
+  slack: criticalmaps:mCh5Cy9Fl2bVMdnQ9ymeYv3H


### PR DESCRIPTION
I activated travis CI for slack and added the notification configuration to the travis file. Now we can get notifications in android channel on slack after each build. I already implemented this in the ios project and really liked it!