### PR TITLE
Multiple code improvements - squid:S1319, squid:S1213, squid:UselessParenthesesCheck

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/ChatMessageAdapter.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/ChatMessageAdapter.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 
 import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -21,9 +22,9 @@ import de.stephanlindauer.criticalmaps.vo.chat.ReceivedChatMessage;
 
 public class ChatMessageAdapter extends RecyclerView.Adapter<ChatMessageAdapter.ChatMessageViewHolder> {
 
-    private final ArrayList<IChatMessage> chatMessages;
+    private final List<IChatMessage> chatMessages;
 
-    public ChatMessageAdapter(ArrayList<IChatMessage> chatMessages) {
+    public ChatMessageAdapter(List<IChatMessage> chatMessages) {
         this.chatMessages = chatMessages;
     }
 

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/TweetAdapter.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/TweetAdapter.java
@@ -17,6 +17,7 @@ import com.squareup.picasso.Picasso;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.List;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
@@ -26,12 +27,12 @@ import de.stephanlindauer.criticalmaps.vo.twitter.Tweet;
 
 public class TweetAdapter extends ArrayAdapter<Tweet> {
 
-    private final ArrayList<Tweet> tweets;
+    private final List<Tweet> tweets;
     private final Context context;
 
     final Picasso picasso = App.components().picasso();
 
-    public TweetAdapter(Context context, int layoutResourceId, ArrayList<Tweet> tweets) {
+    public TweetAdapter(Context context, int layoutResourceId, List<Tweet> tweets) {
         super(context, layoutResourceId, tweets);
         this.tweets = tweets;
         this.context = context;

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/managers/LocationUpdateManager.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/managers/LocationUpdateManager.java
@@ -40,6 +40,27 @@ public class LocationUpdateManager {
     private LongPreference timeStampPreference;
     private boolean isRegisteredForLocationUpdates;
     private Location lastPublishedLocation;
+    private final LocationListener locationListener = new LocationListener() {
+        @Override
+        public void onLocationChanged(final Location location) {
+            if (shouldPublishNewLocation(location)) {
+                publishNewLocation(location);
+                lastPublishedLocation = location;
+            }
+        }
+
+        @Override
+        public void onStatusChanged(String s, int i, Bundle bundle) {
+        }
+
+        @Override
+        public void onProviderEnabled(String s) {
+        }
+
+        @Override
+        public void onProviderDisabled(String s) {
+        }
+    };
 
     @Inject
     public LocationUpdateManager(App app,
@@ -144,25 +165,4 @@ public class LocationUpdateManager {
         return false;
     }
 
-    private final LocationListener locationListener = new LocationListener() {
-        @Override
-        public void onLocationChanged(final Location location) {
-            if (shouldPublishNewLocation(location)) {
-                publishNewLocation(location);
-                lastPublishedLocation = location;
-            }
-        }
-
-        @Override
-        public void onStatusChanged(String s, int i, Bundle bundle) {
-        }
-
-        @Override
-        public void onProviderEnabled(String s) {
-        }
-
-        @Override
-        public void onProviderDisabled(String s) {
-        }
-    };
 }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/model/ChatModel.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/model/ChatModel.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 
 import de.stephanlindauer.criticalmaps.interfaces.IChatMessage;
 import de.stephanlindauer.criticalmaps.vo.chat.OutgoingChatMessage;
@@ -20,9 +21,9 @@ import de.stephanlindauer.criticalmaps.vo.chat.ReceivedChatMessage;
 
 public class ChatModel {
 
-    private final ArrayList<OutgoingChatMessage> outgoingMassages = new ArrayList<>();
+    private final List<OutgoingChatMessage> outgoingMassages = new ArrayList<>();
 
-    private ArrayList<ReceivedChatMessage> chatMessages = new ArrayList<>();
+    private List<ReceivedChatMessage> chatMessages = new ArrayList<>();
 
     public void setNewJson(JSONObject jsonObject) throws JSONException, UnsupportedEncodingException {
         if (chatMessages == null) {

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/model/OwnLocationModel.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/model/OwnLocationModel.java
@@ -21,7 +21,7 @@ public class OwnLocationModel {
 
     public void setLocation(@NonNull GeoPoint location, float accuracy, long time) {
         ownLocation = location;
-        isLocationPrecise = (accuracy < ACCURACY_PRECISE_THRESHOLD);
+        isLocationPrecise = accuracy < ACCURACY_PRECISE_THRESHOLD;
         timeOfFix = time;
     }
 

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/model/TwitterModel.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/model/TwitterModel.java
@@ -6,13 +6,14 @@ import org.json.JSONObject;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.List;
 
 import de.stephanlindauer.criticalmaps.utils.TwitterUtils;
 import de.stephanlindauer.criticalmaps.vo.twitter.Tweet;
 
 public class TwitterModel {
 
-    private ArrayList<Tweet> tweets = new ArrayList<>();
+    private List<Tweet> tweets = new ArrayList<>();
 
     public void setTweetsFromJsonString(String tweetsString) throws JSONException, ParseException {
         tweets.clear();
@@ -34,7 +35,7 @@ public class TwitterModel {
         }
     }
 
-    public ArrayList<Tweet> getTweets() {
+    public List<Tweet> getTweets() {
         return tweets;
     }
 }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/views/LicensePanelView.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/views/LicensePanelView.java
@@ -141,16 +141,25 @@ public class LicensePanelView extends LinearLayout {
     }
 
     protected static class SavedState extends BaseSavedState {
-        private final int visibility;
+        public static final Parcelable.Creator<SavedState> CREATOR = new Creator<SavedState>() {
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
 
-        private SavedState(Parcelable superState, int visibility) {
-            super(superState);
-            this.visibility = visibility;
-        }
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
+        private final int visibility;
 
         private SavedState(Parcel in) {
             super(in);
             visibility = in.readInt();
+        }
+
+        private SavedState(Parcelable superState, int visibility) {
+            super(superState);
+            this.visibility = visibility;
         }
 
         public int getVisibility() {
@@ -162,15 +171,5 @@ public class LicensePanelView extends LinearLayout {
             super.writeToParcel(out, flags);
             out.writeInt(visibility);
         }
-
-        public static final Parcelable.Creator<SavedState> CREATOR = new Creator<SavedState>() {
-            public SavedState createFromParcel(Parcel in) {
-                return new SavedState(in);
-            }
-
-            public SavedState[] newArray(int size) {
-                return new SavedState[size];
-            }
-        };
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order. 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava