### PR TITLE
Multiple code improvements - squid:S1148, squid:S1066, squid:SwitchLastCaseIsDefaultCheck, squid:S2184

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/AboutFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/AboutFragment.java
@@ -45,19 +45,17 @@ public class AboutFragment extends Fragment {
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        if (savedInstanceState != null) {
+        if (savedInstanceState != null && Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             // pre KK ScrollViews don't automatically save/restore their scroll state
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                final int scrollviewPosition = savedInstanceState.getInt(KEY_SCROLLVIEW_POSITION, 0);
+            final int scrollviewPosition = savedInstanceState.getInt(KEY_SCROLLVIEW_POSITION, 0);
 
-                if (scrollviewPosition != 0) {
-                    // needs to be put on the queue so it executes when the view becomes visible
-                    scrollView.post(new Runnable() {
-                        public void run() {
-                            scrollView.scrollTo(0, scrollviewPosition);
-                        }
-                    });
-                }
+            if (scrollviewPosition != 0) {
+                // needs to be put on the queue so it executes when the view becomes visible
+                scrollView.post(new Runnable() {
+                    public void run() {
+                        scrollView.scrollTo(0, scrollviewPosition);
+                    }
+                });
             }
         }
 

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
@@ -121,6 +121,8 @@ public class ChatFragment extends Fragment {
                     case MotionEvent.ACTION_UP:
                         isScrolling = false;
                         return false;
+                    default:
+                        break;
                 }
                 return false;
             }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/managers/LocationUpdateManager.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/managers/LocationUpdateManager.java
@@ -31,7 +31,7 @@ public class LocationUpdateManager {
 
     //const
     private static final float LOCATION_REFRESH_DISTANCE = 20; //20 meters
-    private static final long LOCATION_REFRESH_TIME = 12 * 1000; //12 seconds
+    private static final long LOCATION_REFRESH_TIME = 12 * 1000L; //12 seconds
 
     //misc
     private LocationManager locationManager;

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/AeSimpleSHA1.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/AeSimpleSHA1.java
@@ -1,12 +1,15 @@
 package de.stephanlindauer.criticalmaps.utils;
 
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class AeSimpleSHA1 {
+
+    private static final String LOG_TAG = "CM_AeSimpleSHA1";
 
     @Nullable
     public static String SHA1(String text) {
@@ -16,7 +19,7 @@ public class AeSimpleSHA1 {
             final byte[] sha1hash = md.digest();
             return convertToHex(sha1hash);
         } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
-            e.printStackTrace();
+            Log.e(LOG_TAG, Log.getStackTraceString(e));
             return null;
         }
     }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/ImageUtils.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/ImageUtils.java
@@ -5,12 +5,15 @@ import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.media.ExifInterface;
 import android.os.Environment;
+import android.util.Log;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
 public class ImageUtils {
+
+    private static final String LOG_TAG = "CM_ImageUtils";
 
     public static Bitmap rotateBitmap(File photoFile) {
         Bitmap sourceBitmap = BitmapFactory.decodeFile(photoFile.getPath());
@@ -20,7 +23,7 @@ public class ImageUtils {
             ExifInterface exif = new ExifInterface(photoFile.getPath());
             orientString = exif.getAttribute(ExifInterface.TAG_ORIENTATION);
         } catch (IOException e) {
-            e.printStackTrace();
+            Log.e(LOG_TAG, Log.getStackTraceString(e));
         }
 
         int orientation = Integer.parseInt(orientString);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S1066 - Collapsible "if" statements should be merged. 
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S2184 - Math operands should be cast before assignment.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
George Kankava
