### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/DateUtils.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/DateUtils.java
@@ -5,6 +5,9 @@ import android.support.annotation.NonNull;
 import java.util.Date;
 
 public class DateUtils {
+
+    private DateUtils() {}
+
     public static boolean isNotLongerAgoThen(@NonNull Date timestamp, int minutes, int seconds) {
         long differenceInMs = timestamp.getTime() - new Date().getTime();
         return differenceInMs <= (minutes * 60 + seconds) * 1000;

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/ImageUtils.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/ImageUtils.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 
 public class ImageUtils {
 
+    private ImageUtils() {}
+
     public static Bitmap rotateBitmap(File photoFile) {
         Bitmap sourceBitmap = BitmapFactory.decodeFile(photoFile.getPath());
 

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/IntentUtil.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/IntentUtil.java
@@ -7,6 +7,8 @@ import android.view.View;
 
 public class IntentUtil {
 
+    private IntentUtil() {}
+
     public static void startFromURL(final Context context, final String urlString) {
         final Intent i = new Intent(Intent.ACTION_VIEW);
         i.setData(Uri.parse(urlString));

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/LocationUtils.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/LocationUtils.java
@@ -8,6 +8,9 @@ import org.osmdroid.util.GeoPoint;
 import static android.location.LocationManager.*;
 
 public class LocationUtils {
+
+    private LocationUtils() {}
+
     @Nullable
     public static GeoPoint getBestLastKnownLocation(LocationManager locationManager) {
         final String[] providers = new String[]{GPS_PROVIDER, NETWORK_PROVIDER, PASSIVE_PROVIDER};

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/MapViewUtils.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/MapViewUtils.java
@@ -11,6 +11,8 @@ public class MapViewUtils {
 
     private static final int TILE_SIZE_PIXELS = 256; //osmdroid default
 
+    private MapViewUtils() {}
+
     public static MapView createMapView(Activity activity, DefaultResourceProxyImpl resourceProxy) {
 
         MapView mapView = new MapView(activity, TILE_SIZE_PIXELS, resourceProxy);

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/TwitterUtils.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/TwitterUtils.java
@@ -6,6 +6,9 @@ import java.util.Date;
 import java.util.Locale;
 
 public class TwitterUtils {
+
+    private TwitterUtils() {}
+
     public static Date getTwitterDate(String date) throws ParseException {
         String twitterTimeFormat = "EEE MMM dd HH:mm:ss ZZZZZ yyyy";
         SimpleDateFormat sf = new SimpleDateFormat(twitterTimeFormat, Locale.ENGLISH);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava