### PR TITLE
Fix crash while discovering storage location and workaround service issues in O

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
     defaultConfig {
         applicationId "de.stephanlindauer.criticalmaps"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 25
         versionCode 32
         versionName "2.4.0"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/service/ServerSyncService.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/service/ServerSyncService.java
@@ -4,6 +4,7 @@ import android.app.Service;
 import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
+import android.support.v4.content.ContextCompat;
 
 import com.squareup.otto.Subscribe;
 
@@ -104,11 +105,7 @@ public class ServerSyncService extends Service {
     public static void startService() {
         App app = App.components().app();
         Intent syncServiceIntent = new Intent(app, ServerSyncService.class);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            app.startForegroundService(syncServiceIntent);
-        } else {
-            app.startService(syncServiceIntent);
-        }
+        ContextCompat.startForegroundService(app, syncServiceIntent);
     }
 
     public static void stopService() {

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/utils/MapViewUtils.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/utils/MapViewUtils.java
@@ -117,13 +117,19 @@ public class MapViewUtils {
     }
 
     private static File getBestStorageLocation(Context context) {
-        Timber.d("Finding best storage Location.");
+        Timber.d("Finding best storage location.");
 
         ArrayList<File> storageDirs = new ArrayList<>(3);
         storageDirs.add(context.getFilesDir());
 
         File[] externalDirs = ContextCompat.getExternalFilesDirs(context, null);
         for (File externalDir : externalDirs) {
+            // "Returned paths may be null if a storage device is unavailable."
+            if (externalDir == null) {
+                Timber.d("Storage location is null (=unavailable), skipping.");
+                continue;
+            }
+
             String state = EnvironmentCompat.getStorageState(externalDir);
             if (Environment.MEDIA_MOUNTED.equals(state)) {
                 storageDirs.add(externalDir);


### PR DESCRIPTION
Individual paths returned by getExternalFilesDirs() can be null when
they are unavailable. Handle that case by skipping the location.