### PR TITLE
Disable 'Send' button if message is empty

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
@@ -103,7 +103,8 @@ public class ChatFragment extends Fragment {
     public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
 
-        updateSendButtonEnabledState();
+        final String message = editMessageTextField.getText().toString();
+        sendButton.setEnabled(!message.trim().isEmpty());
 
         editMessageTextField.addTextChangedListener(new SimpleTextWatcher() {
             @Override
@@ -145,7 +146,7 @@ public class ChatFragment extends Fragment {
 
     @OnClick(R.id.chat_send_btn)
     void handleSendClicked() {
-        String message = editMessageTextField.getText().toString().trim();
+        final String message = editMessageTextField.getText().toString().trim();
 
         if (message.isEmpty()) {
             return;
@@ -158,7 +159,7 @@ public class ChatFragment extends Fragment {
     }
 
     private void displayNewData() {
-        List<IChatMessage> savedAndOutgoingMessages = chatModel.getSavedAndOutgoingMessages();
+        final List<IChatMessage> savedAndOutgoingMessages = chatModel.getSavedAndOutgoingMessages();
         chatMessageAdapter.updateData(savedAndOutgoingMessages);
 
         if (chatRecyclerView.getScrollState() ==  RecyclerView.SCROLL_STATE_IDLE) {
@@ -213,7 +214,7 @@ public class ChatFragment extends Fragment {
     }
 
     private void updateSendButtonEnabledState() {
-        String message = editMessageTextField.getText().toString();
+        final String message = editMessageTextField.getText().toString();
         setSendButtonEnabledWithAnimation(!message.trim().isEmpty());
     }
 }

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/fragments/ChatFragment.java
@@ -69,7 +69,6 @@ public class ChatFragment extends Fragment {
 
     //misc
     private boolean isTextInputEnabled = true;
-    private boolean isDataConnectionAvailable = true;
     private ChatMessageAdapter chatMessageAdapter;
     private Unbinder unbinder;
 
@@ -104,12 +103,12 @@ public class ChatFragment extends Fragment {
     public void onViewStateRestored(@Nullable Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
 
-        sendButton.setEnabled(editMessageTextField.getText().length() > 0);
+        updateSendButtonEnabledState();
 
         editMessageTextField.addTextChangedListener(new SimpleTextWatcher() {
             @Override
             public void afterTextChanged(Editable s) {
-                setSendButtonEnabledWithAnimation(s.length() > 0);
+                updateSendButtonEnabledState();
             }
         });
     }
@@ -146,7 +145,7 @@ public class ChatFragment extends Fragment {
 
     @OnClick(R.id.chat_send_btn)
     void handleSendClicked() {
-        String message = editMessageTextField.getText().toString();
+        String message = editMessageTextField.getText().toString().trim();
 
         if (message.isEmpty()) {
             return;
@@ -196,8 +195,7 @@ public class ChatFragment extends Fragment {
     @SuppressWarnings("unused")
     @Subscribe
     public void handleNetworkConnectivityChanged(NetworkConnectivityChangedEvent e) {
-        isDataConnectionAvailable = e.isConnected;
-        setTextInputState(isDataConnectionAvailable);
+        setTextInputState(e.isConnected);
     }
 
     private void setTextInputState(final boolean dataEnabled) {
@@ -207,12 +205,15 @@ public class ChatFragment extends Fragment {
             textInputLayout.setHint(getString(R.string.chat_no_data_connection_hint));
             isTextInputEnabled = false;
         } else if (!isTextInputEnabled) {
-            if (editMessageTextField.getText().length() > 0) {
-                setSendButtonEnabledWithAnimation(true);
-            }
+            updateSendButtonEnabledState();
             editMessageTextField.setEnabled(true);
             textInputLayout.setHint(getString(R.string.chat_text));
             isTextInputEnabled = true;
         }
+    }
+
+    private void updateSendButtonEnabledState() {
+        String message = editMessageTextField.getText().toString();
+        setSendButtonEnabledWithAnimation(!message.trim().isEmpty());
     }
 }


### PR DESCRIPTION
@cbalster @stephanlindauer 
1) I think we should disable 'Send message' button if trimmed message is empty. Now an user can send empty or started with white spaces message. It looks like a spam.
2) An unused private variable removed

![image](https://user-images.githubusercontent.com/3222305/67678519-fca8ec00-f9b0-11e9-8951-87f68d3d147c.png)
