### PR TITLE
Fix chat animation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ android {
 
 dependencies {
     implementation 'com.squareup:otto:1.3.8'
-    implementation 'org.osmdroid:osmdroid-android:6.1.0'
+    implementation 'org.osmdroid:osmdroid-android:6.1.2'
     implementation 'com.squareup.picasso:picasso:2.5.2'
     implementation 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/ChatMessageAdapter.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/ChatMessageAdapter.java
@@ -34,13 +34,13 @@ public class ChatMessageAdapter extends RecyclerView.Adapter<ChatMessageAdapter.
         @BindView(R.id.secondLine)
         TextView valueView;
 
+        private ObjectAnimator sendingAnimator;
+
         private final DateFormat dateFormatter = DateFormat.getDateTimeInstance(
                 DateFormat.DEFAULT, DateFormat.SHORT, Locale.getDefault());
-        private final Context context;
 
         public ChatMessageViewHolder(View itemView) {
             super(itemView);
-            context = itemView.getContext();
             ButterKnife.bind(this, itemView);
         }
 
@@ -49,14 +49,17 @@ public class ChatMessageAdapter extends RecyclerView.Adapter<ChatMessageAdapter.
             if (message instanceof ReceivedChatMessage) {
                 dateFormatter.setTimeZone(TimeZone.getDefault());
                 labelView.setText(TimeToWordStringConverter.getTimeAgo(
-                        ((ReceivedChatMessage) message).getTimestamp(), context));
-                labelView.clearAnimation();
+                        ((ReceivedChatMessage) message).getTimestamp(), itemView.getContext()));
+                if (sendingAnimator != null) {
+                    sendingAnimator.end();
+                    labelView.setAlpha(1f);
+                    sendingAnimator = null;
+                }
             } else {
                 labelView.setText(R.string.chat_sending);
 
-                ObjectAnimator sendingAnimator = (ObjectAnimator) AnimatorInflater.loadAnimator(
-                        itemView.getContext(),
-                        R.animator.map_gps_fab_searching_animation);
+                sendingAnimator = (ObjectAnimator) AnimatorInflater.loadAnimator(
+                        itemView.getContext(), R.animator.map_gps_fab_searching_animation);
                 sendingAnimator.setTarget(labelView);
                 sendingAnimator.start();
             }


### PR DESCRIPTION
For some reason the animation on reused viewholders was triggered again, resulting in some received items animating like a sending message. This fixes that by keeping an explicit reference to the animation per view holder an canceling it directly instead of cancelling via the the view. 