### PR TITLE
fix wrong twitter handle linkage

### DIFF
--- a/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/TweetAdapter.java
+++ b/app/src/main/java/de/stephanlindauer/criticalmaps/adapter/TweetAdapter.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import de.stephanlindauer.criticalmaps.App;
@@ -120,7 +121,7 @@ public class TweetAdapter extends RecyclerView.Adapter<TweetAdapter.TweetViewHol
 
             itemView.setOnClickListener(v ->
                     context.startActivity(new Intent(Intent.ACTION_VIEW,
-                            Uri.parse("https://twitter.com/aasif/status/" + tweet.getTweetId()))));
+                            Uri.parse("https://twitter.com/" + tweet.getUserScreenName() + "/status/" + tweet.getTweetId()))));
         }
     }
 }


### PR DESCRIPTION
Not sure why it linked to Aasiv Mandvis account. :laughing: 
Even with the wrong user handle it always displayed the correct tweet in the end. :confused: 

![image](https://media.giphy.com/media/dW0uHTbIV9b2u3bkKi/giphy.gif)

