### PR TITLE
Add diagrams link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Yep! Here: https://github.com/CriticalMaps/criticalmaps-ios
 *   If you can code: Just go ahead and send us a pull request. If you're planning a bigger feature, it might be a good idea to open an [issue](https://github.com/criticalmaps/criticalmaps-android/issues) before starting in case someone is working on something similar.
 *   If you find bugs: File them in the [github issue tracking system](https://github.com/criticalmaps/criticalmaps-android/issues).
 *   If you find translation errors or want to add a new language: Head over to our [Transifex site](https://www.transifex.com/criticalmaps/criticalmaps/) and join a translation team.
+*   To get acquainted with project structure please refer to [model, class and other diagrams](https://sourcespy.com/github/criticalmapscriticalmapsandroid).
 *   If you have moneyz left to burn: Help us finance the server.
 
 ## Can i haz more information?


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/criticalmapscriticalmapsandroid/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.