### PR TITLE
Fix navigation drawer not switching screens on first launch

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,10 @@
     android:layout_height="match_parent"
     tools:keep="@layout/activity_main">
 
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -48,19 +52,6 @@
             tools:ignore="HardcodedText" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
-    <com.google.android.material.navigation.NavigationView
-        android:id="@+id/drawer_navigation"
-        android:layout_width="280dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:background="@color/colorSurface"
-        app:elevation="0dp"
-        app:headerLayout="@layout/navdrawer_header"
-        app:itemBackground="@drawable/nav_drawer_item_background_states"
-        app:itemIconTint="@color/nav_item_icon_tint"
-        app:itemTextColor="@color/nav_item_text"
-        app:menu="@menu/menu_navdrawer" />
 
     <LinearLayout
         android:id="@+id/introduction_view"
@@ -107,5 +98,20 @@
             android:textColor="@color/colorBackground"
             android:theme="@style/AlertDialogTheme" />
     </LinearLayout>
+
+    </FrameLayout>
+
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/drawer_navigation"
+        android:layout_width="280dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:background="@color/colorSurface"
+        app:elevation="0dp"
+        app:headerLayout="@layout/navdrawer_header"
+        app:itemBackground="@drawable/nav_drawer_item_background_states"
+        app:itemIconTint="@color/nav_item_icon_tint"
+        app:itemTextColor="@color/nav_item_text"
+        app:menu="@menu/menu_navdrawer" />
 
 </androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
## What

Fixes the first-launch bug where the navigation drawer opens but tapping a menu entry (Chat / Rules / Settings / About) does not switch screens — the app stays on Map until it is force-stopped and relaunched.

Fixes #373.

## Root cause

`activity_main.xml` gave `DrawerLayout` **two** content children plus the drawer:

```
DrawerLayout
 ├─ CoordinatorLayout   (content_frame + toolbar)   ← content child #1
 ├─ NavigationView      (layout_gravity="start")      ← drawer
 └─ LinearLayout @+id/introduction_view               ← content child #2 (no layout_gravity)
```

`introduction_view` is a full-screen, `clickable`/`focusable` view with **no** `layout_gravity`, so `DrawerLayout` treats it as a second content view. It is only shown on first launch (until the privacy policy is accepted) and then hidden. Showing then hiding that extra content child leaves `DrawerLayout`'s touch handling broken for the session: taps on `NavigationView` rows are swallowed as a "close drawer" gesture, so `onNavigationItemSelected` never fires. A restart recreates the hierarchy cleanly and the overlay is never shown again, which is why a restart "fixes" it.

## Fix

Wrap the content and the intro overlay in a single `FrameLayout` so `DrawerLayout` has exactly one content child plus the `NavigationView` drawer. Layout-only change — no Java changes.

## Testing

Verified on a Pixel emulator (API 36) against `master`:

| | Tap Chat on first launch |
|---|---|
| **Before** | drawer closes, stays on Map; `onNavigationItemSelected` never fires |
| **After** | navigates to ChatFragment; Rules/Settings also verified |

Confirmed via `dumpsys activity top` (fragment swap) and instrumented `onNavigationItemSelected` / `onDrawerClosed` / `navigateTo` logging on both first-launch and post-restart paths.

## Note

A Kotlin/Compose rewrite exists on `migrate_to_kotlin_and_compose`, but `master` still ships this Java/XML screen, so this targets `master`. If the Compose UI replaces this screen, the same "single content child under the drawer" rule should carry over.
